### PR TITLE
➕ [WOW-30] feat : common-button 컴포넌트 생성

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,3 +1,4 @@
+import CustomButton from "@/components/common/custom-button";
 import { createTranslation } from "../../utils/localization/server";
 import { LocaleTypes } from "../../utils/localization/settings";
 
@@ -12,6 +13,30 @@ export default async function Home({
     <div className="test-container">
       <h1>{t("greeting")}</h1>
       <h3>{t("description")}</h3>
+      <div className="flex flex-col gap-2">
+        <CustomButton height="large" variant="disabled" fontWeight="bold">
+          disabled button
+        </CustomButton>
+        <CustomButton height="large" variant="filled" fontWeight="bold">
+          filled button
+        </CustomButton>
+        <CustomButton height="large" variant="outline" fontWeight="bold">
+          outline button
+        </CustomButton>
+        <CustomButton height="large" variant="outlineColor" fontWeight="bold">
+          filled button
+        </CustomButton>
+      </div>
+      <div className="grid grid-cols-[250px_auto] gap-1">
+        {/* 첫번째열 250px 고정너비 가지고 두번째열은 남는 공간 차지 */}
+        <input
+          placeholder="닉네임을 입력해주세요"
+          className="border border-bg-black h-14 px-4 py-[14px] bg-SYSTEM-white"
+        />
+        <CustomButton height="large" variant="outlineColor" fontWeight="bold">
+          중복확인
+        </CustomButton>
+      </div>
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
         <LocaleButton />
         <div className="min-h-screen flex justify-center items-center bg-gray-300">
           <br />
-          <div className="w-full sm:w-[375px] min-h-screen md:min-h-[738px] bg-white">
+          <div className="w-full sm:w-[375px] min-h-screen md:min-h-[738px] bg-white p-4">
             {children}
           </div>
         </div>

--- a/src/components/common/custom-button.tsx
+++ b/src/components/common/custom-button.tsx
@@ -1,0 +1,30 @@
+import clsx from "clsx";
+
+const CustomButton = ({
+  height,
+  variant = "filled",
+  fontWeight = "normal",
+  className,
+  ...props
+}: CustomButtonProps) => {
+  const buttonClass = clsx(
+    "rounded-sm cursor-pointer  w-full text-lg flex  justify-center items-center", // 공통 스타일
+    {
+      " h-11": height === "small",
+      "h-14": height === "large",
+      "bg-SYSTEM-main text-SYSTEM-white": variant === "filled",
+      "bg-ELSE-D9 text-SYSTEM-white ": variant === "disabled",
+      "bg-SYSTEM-white border border-ELSE-D9 text-ELSE-D9":
+        variant === "outline",
+      "bg-SYSTEM-white border border-SYSTEM-main text-SYSTEM-main":
+        variant === "outlineColor",
+      "font-bold": fontWeight === "bold",
+      "font-normal": fontWeight === "normal",
+    },
+    className
+  );
+
+  return <button className={buttonClass} {...props}></button>;
+};
+
+export default CustomButton;

--- a/src/components/common/types.d.ts
+++ b/src/components/common/types.d.ts
@@ -19,3 +19,9 @@ type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   alt: string;
   isActive?: boolean;
 };
+
+type CustomButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  height: "large" | "small";
+  variant: "filled" | "disabled" | "outline" | "outlineColor";
+  fontWeight: "bold" | "normal";
+};


### PR DESCRIPTION
## 개요

 common button 컴포넌트 생성

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
### 1. [📌 WOW-30 setting : layout 에 padding 설정](https://github.com/WoWmazon/wowmazon/commit/575abb362d69de2408383f26a140185cdf5a3842)
일단 피그마에있는대로 layout에 padding값 16px를 임의로 추가하였습니다.

### 2. [➕ WOW-30 feat : common-button 컴포넌트 생성](https://github.com/WoWmazon/wowmazon/commit/89dc5ebe00e169a34822a8671b50f71125b9b492)
아래 피그마에서 공용버튼 컴포넌트를 보시면, **높이와 폰트굵기, 보더, 폰트색, 버튼배경색** 외에는 공통으로 스타일을 가지는것을볼수있습니다.
![image](https://github.com/user-attachments/assets/81345c01-ceb8-4a5e-a855-f30344dc1211)

따라서, clsx를 사용하여 공통 스타일을 정의하고 props로 변경되는 부분만 받을수 있게끔 만들었는데 심히 가독성이 떨어지는것 같네요,, ㅠㅜ

```tsx
type CustomButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
  height: "large" | "small";
  variant: "filled" | "disabled" | "outline" | "outlineColor";
  fontWeight: "bold" | "normal";
};
```
- variant 의 속성 이름은 피그마에 있는 버튼 이름으로 고대로 따서 선언하였습니다.

#### input과 customButton 컴포넌트를 같이 사용할때, customButton 인 `중복확인`버튼의 너비와 input너비의 문제

오프라인으로 만나 회의했을때, input 의 너비를 w-[250px] 로 고정하고  customButton을 w-full 로 했었는데 `input의 너비가 205px로 되었던 이슈`가있었습니다. 

해당문제의 원인은, input을 그냥 너비로 설정하고 customButton을 w-full로 설정했기때문에 customButton이 전체 너비를 차지하려고해서 input 의 크기가 줄어든것이였습니다.
이문제를 해결하기 위해 두가지 방법이 있습니다.

- ##### `input값`에 `최소 너비` 설정해주기
input 값에 그냥 너비가 아닌 최소 너비를 설정해준다면 customButton의 너비가 full이여도 input의 영역을 침범하지않습니다.
-> 하지만 이방법은 지금 당장은 매우 쉽게 해결될지 몰라도 나중에 화면 크기에 따라 반응형을 구현할때 계속해서 min-width를 화면 크기마다 설정해줘야하는 문제가 생깁니다.

- ##### flex가 아닌 `grid로 설정하고 input에만 너비` 넣어주기
grid 속성은 저도 잘 사용해보지않아서 익숙치 않지만 grid로 작성한다면 input 너비만 설정해줘도 자동으로 customButton의 너비가 fix됩니다.
+ 덧붙여서 반응형 레이아웃에서 화면 크기에 따라 flex 보다 더 간단하게 크기조정이 가능합니다.
회원가입/로그인 페이지 만드시는 @ljs614 님 ㅋㅋ 한번 적용해보십쇼 tailwind에서 grid 속성 잘 사용하면 좋을듯???????

```tsx
<div className="grid grid-cols-[250px_auto] gap-1">
{/* 첫번째열 250px 고정너비 가지고 두번째열은 남는 공간 차지 */}
   <input
     placeholder="닉네임을 입력해주세요"
      className="border border-bg-black h-14 px-4 py-[14px] bg-SYSTEM-white"
        />
    <CustomButton height="large" variant="outlineColor" fontWeight="bold">
       중복확인
    </CustomButton>
</div>
```
<위 코드 화면 구현시,,>
![image](https://github.com/user-attachments/assets/7ccb5631-6a6b-4722-a31a-7f09bf8d7f10)
해당 코드는 [locale]/page.tsx 에서 testcode로 살짝쿵 작성해놓았습니다!

#### CustomButton을 사용하시려면? 요롷게~
```tsx
 <CustomButton height="large" variant="outlineColor" fontWeight="bold">
          filled button
 </CustomButton>
```

<br/>

## When modifying code...


```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```