### PR TITLE
➕ [WOW-35] feat : wish list 페이지 생성

### DIFF
--- a/src/app/[locale]/(main)/wish-list/page.tsx
+++ b/src/app/[locale]/(main)/wish-list/page.tsx
@@ -1,4 +1,13 @@
-const page = () => {
-  return <div>wish list page</div>;
+import WishListHeader from "@/components/wish-list/wish-list-header";
+import WishListNoContents from "@/components/wish-list/wish-list-nonecontents";
+
+const page = ({ params: { locale } }: WishListNoContentsProps) => {
+  const number = 5; //예시
+  return (
+    <div className="grid gap-4">
+      <WishListHeader wishListNumber={number} />
+      <WishListNoContents params={{ locale }} />
+    </div>
+  );
 };
 export default page;

--- a/src/components/wish-list/types.d.ts
+++ b/src/components/wish-list/types.d.ts
@@ -1,0 +1,5 @@
+type WishListNoContentsProps = {
+  params: {
+    locale: LocaleTypes;
+  };
+};

--- a/src/components/wish-list/wish-list-header.tsx
+++ b/src/components/wish-list/wish-list-header.tsx
@@ -1,0 +1,53 @@
+"use client";
+import alram from "@/assets/icons/header_alarm.svg";
+import activeAlram from "@/assets/icons/header_alarm_redDot.svg";
+import { useTranslation } from "@/utils/localization/client";
+import { LocaleTypes } from "@/utils/localization/settings";
+import { useParams } from "next/navigation";
+import IconButton from "../common/custom-icon-button";
+import { useState } from "react";
+type WishListHeaderProps = {
+  wishListNumber: number;
+};
+const WishListHeader = ({ wishListNumber }: WishListHeaderProps) => {
+  const locale = useParams()?.locale as LocaleTypes;
+  const { t } = useTranslation(locale, "common");
+  const [isActive, setIsActive] = useState(false);
+
+  const handleIconClick = () => {
+    setIsActive((prev) => !prev);
+  };
+  return (
+    <>
+      <div className="grid grid-cols-[1fr_auto] items-center h-8">
+        <p className="text-xxl">
+          {t("wishList")}({wishListNumber})
+        </p>
+        <IconButton
+          icon={alram}
+          activeIcon={activeAlram}
+          size={32}
+          alt="alram-icon"
+          isActive={isActive}
+          onClick={handleIconClick}
+          className="justify-self-end"
+        />
+      </div>
+      <div className="grid grid-cols-[auto_auto]  items-center mt-4  text-ELSE-D9">
+        <div className="grid grid-flow-col auto-cols-max items-center gap-2">
+          <button className=" text-md hover:text-ELSE-55">
+            {t("discountRateOrder")}
+          </button>
+          <span className="mx-2"> | </span>
+          <button className=" text-md hover:text-ELSE-55">
+            {t("lowToHigh")}
+          </button>
+        </div>
+        <button className=" text-md justify-self-end hover:text-ELSE-55">
+          {t("edit")}
+        </button>
+      </div>
+    </>
+  );
+};
+export default WishListHeader;

--- a/src/components/wish-list/wish-list-nonecontents.tsx
+++ b/src/components/wish-list/wish-list-nonecontents.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import heartIcon from "@/assets/icons/nav_wishList_gray.svg";
+import { createTranslation } from "@/utils/localization/server";
+
+const WishListNoContents = async ({
+  params: { locale },
+}: WishListNoContentsProps) => {
+  const { t } = await createTranslation(locale, "common");
+  return (
+    <div className="grid  place-items-center w-[343px] h-[478px]">
+      <div className="grid  place-items-center w-[343px] h-[154px] ">
+        <Image src={heartIcon} alt="heartIcon" width={80} height={80} />
+        <div className="grid grid-cols-1 gap-[6px] text-center ">
+          <p className="text-lg text-ELSE-55">{t("wishListNoContents")}</p>
+          <p className="text-md text-ELSE-F8">
+            {t("wishLostNoContentsDescription")}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default WishListNoContents;

--- a/src/utils/localization/locales/en/common.json
+++ b/src/utils/localization/locales/en/common.json
@@ -8,5 +8,11 @@
   "retry": "Retry",
   "notice": "Notice",
   "lowestPrice": "Lowest Price",
-  "highestPrice": "Highest Price"
+  "highestPrice": "Highest Price",
+  "wishList": "Wishlist",
+  "discountRateOrder": "Discount rate order",
+  "lowToHigh": "Low to High",
+  "edit": "Edit",
+  "wishListNoContents": "There are no desired products yet.",
+  "wishLostNoContentsDescription": "Click the + button below to include the product you want to be notified of the lowest price!"
 }

--- a/src/utils/localization/locales/ko/common.json
+++ b/src/utils/localization/locales/ko/common.json
@@ -8,5 +8,11 @@
   "retry": "재시도",
   "notice": "안내",
   "lowestPrice": "역대 최저가",
-  "highestPrice": "역대 최고가"
+  "highestPrice": "역대 최고가",
+  "wishList": "찜한 상품",
+  "discountRateOrder": "할인율순",
+  "lowToHigh": "낮은 가격순",
+  "edit": "편집",
+  "wishListNoContents": "아직 찜한 상품이 없어요.",
+  "wishLostNoContentsDescription": "아래 + 버튼을 눌러 최저가 알림 받고싶은 상품을 담아보세요!"
 }


### PR DESCRIPTION
## 개요

[➕ WOW-35 feat : wish list 페이지 생성](https://github.com/WoWmazon/wowmazon/commit/562f696461f0a2bddd0be82a8b2d36b2340b47ae)

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
일단 메인페이지에서 `데이터가 없을때의 페이지` 만들었습니다.

<img width="789" alt="스크린샷 2024-10-18 오후 8 33 51" src="https://github.com/user-attachments/assets/245f9f77-8c82-49ee-8dba-fd033bf3091e">

원래 bottom-nav부터 만드려고 했는데 , 그 컴포넌트는 상세페이지 , 로그인/회원가입 페이지 제외하고 다 밑에 footer처럼 들어가는것같아서 코드를 짤때 좀더 생각이 필요할것같아 일단 더 빨리 끝나는 페이지 먼저 만들었습니다.

<div align="center">
<img src="https://github.com/user-attachments/assets/4c38f94a-7a8f-48da-a125-1053072598be" width="246"/>
<img src="https://github.com/user-attachments/assets/a3868149-422c-4396-a951-d2b8575ba273" width="246"height="350"/>
</div>


다국어 지원도 같이 만들었는데, 서버 컴포넌트에서 불러올때 params로 받을수 밖에 없는 이 상황을 어떻게 해결해야할지 다같이 고민을 해봐야할것같습니다.,, 흠,,, 서버 페이지에서 아예 사용할때는 괜찮을것같은데 서버 컴포넌트에서 사용하려면,, 어떻게 하는게 좋을까요? 

일단 찜한상품이 없을때의 컴포넌트는 굳이 클라이언트일 필요가 없을것같아 서버 컴포넌트로 만들었습니다. 

https://github.com/user-attachments/assets/17b7165e-ec0b-4b97-9c72-9304237c3d67



## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```