### PR TITLE
➕ [WOW-62] feat: product card skeleton 추가

### DIFF
--- a/src/app/[locale]/(main)/test-page/page.tsx
+++ b/src/app/[locale]/(main)/test-page/page.tsx
@@ -1,4 +1,5 @@
 import CustomButton from "@/components/common/custom-button";
+import ProductCardSkelton from "@/components/skeletons/product-card-skeleton";
 import TestButton from "@/components/test-button";
 import TestComponents from "@/components/test/test-components";
 import { createTranslation } from "@/utils/localization/server";
@@ -30,6 +31,9 @@ export default async function Home({
           <CustomButton smallSize variant="outlineColor">
             filled button
           </CustomButton>
+        </div>
+        <div className="my-4">
+          <ProductCardSkelton />
         </div>
         <br />
         <div className="grid grid-cols-[250px_auto] gap-1">

--- a/src/components/skeletons/product-card-skeleton.tsx
+++ b/src/components/skeletons/product-card-skeleton.tsx
@@ -1,0 +1,16 @@
+const ProductCardSkelton = () => {
+  return (
+    <div className="relative flex flex-row gap-4 items-center">
+      <div className="size-20 skeleton-img" />
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-row gap-3">
+          <div className="w-[207px] h-10 skeleton-line" />
+          <div className="size-7 skeleton-icon" />
+        </div>
+        <div className="w-[247px] h-6 skeleton-line" />
+      </div>
+    </div>
+  );
+};
+
+export default ProductCardSkelton;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,2 +1,3 @@
 @import "./globals.css";
 @import "./tailwind.css";
+@import "./skeleton.css";

--- a/src/css/skeleton.css
+++ b/src/css/skeleton.css
@@ -1,0 +1,45 @@
+.skeleton-bg {
+  @apply bg-ELSE-EC bg-no-repeat bg-gradient-to-r from-[0px] from-ELSE-EC via-[40px] via-ELSE-F5 to-[80px] to-ELSE-EC;
+}
+
+.skeleton-img {
+  @apply skeleton-bg;
+  animation: loading-img 1.6s infinite linear;
+}
+
+.skeleton-line {
+  @apply skeleton-bg;
+  animation: loading-line 1.6s infinite linear;
+}
+
+.skeleton-icon {
+  @apply skeleton-bg;
+  animation: loading-icon 1.6s infinite linear;
+}
+
+@keyframes loading-img {
+  0% {
+    background-position-x: -40px;
+  }
+  100% {
+    background-position-x: 343px;
+  }
+}
+
+@keyframes loading-line {
+  0% {
+    background-position: -136px;
+  }
+  100% {
+    background-position-x: 247px;
+  }
+}
+
+@keyframes loading-icon {
+  0% {
+    background-position: -355px;
+  }
+  100% {
+    background-position-x: 28px;
+  }
+}


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
ProductCard Skeleton

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->
### ProductCard의 Skeleton UI 추가

https://github.com/user-attachments/assets/d6519b92-3e03-4d6a-b6df-e53ef5d59e0a

- 다음과 같이 구현하기 위해선 x 위치가 같은 div끼리  animation을 주어야 하기 때문에 3개의 아래와 같이 css를 적용했습니다.

```css
// 스켈레톤 공통
.skeleton-bg {
  @apply bg-ELSE-EC bg-no-repeat bg-gradient-to-r from-[0px] from-ELSE-EC via-[40px] via-ELSE-F5 to-[80px] to-ELSE-EC;
}
// 왼쪽 정사각형 이미지
.skeleton-img {
  @apply skeleton-bg;
  animation: loading-img 1.6s infinite linear;
}
// 가운데 라인
.skeleton-line {
  @apply skeleton-bg;
  animation: loading-line 1.6s infinite linear;
} 
// 오른쪽 아이콘
.skeleton-icon {
  @apply skeleton-bg;
  animation: loading-icon 1.6s infinite linear;
}

@keyframes loading-img {
  0% {
    background-position-x: -40px;
  }
  100% {
    background-position-x: 343px;
  }
}

@keyframes loading-line {
  0% {
    background-position: -136px;
  }
  100% {
    background-position-x: 247px;
  }
}

@keyframes loading-icon {
  0% {
    background-position: -355px;
  }
  100% {
    background-position-x: 28px;
  }
}

```

- 그런데 이렇게 할 경우 고정 크기로 밖에 구현이 안 되어서 반응형으로 리팩토링할 때에는 다른 방법을 써야할듯 합니다.

<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```