### PR TITLE
🔧 [WOW-77] fix:search-page와 product-list의 데이터 문제 해결

### DIFF
--- a/src/components/products/product-list-category-filter.tsx
+++ b/src/components/products/product-list-category-filter.tsx
@@ -32,8 +32,9 @@ const ProductListCategoryFilter = () => {
     isLoading,
     isError,
   } = useInfiniteScrollProductList({
-    category_id: selectedCategoryId,
     ...searchParams,
+    category_id: selectedCategoryId,
+    search: undefined,
   });
 
   /**[카테고리 옵저버] */

--- a/src/components/search/search-container.tsx
+++ b/src/components/search/search-container.tsx
@@ -9,7 +9,7 @@ import SearchFilter from "./search-filter";
 
 const SearchContainer = () => {
   const searchParams = useProductParamsStore((state) => state.searchParams);
-  const hasSearchKeyword = searchParams.search !== "";
+  const hasSearchKeyword = !!searchParams.search;
 
   const { data, isPending, isError, hasNextPage, fetchNextPage } =
     useInfiniteScrollProductList(searchParams, hasSearchKeyword);

--- a/src/stores/prooduct/stores.ts
+++ b/src/stores/prooduct/stores.ts
@@ -34,7 +34,7 @@ export const useRecentKeywordsStore = create<RecentKeywordsState>()(
 );
 
 export const useProductParamsStore = create<ProductParamsState>()((set) => ({
-  searchParams: { search: "", ordering: "-discount_rate" },
+  searchParams: { ordering: "-discount_rate" },
   setSearchParams: (key, value) =>
     set((state) => ({ searchParams: { ...state.searchParams, [key]: value } })),
 }));


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
- search page에서 검색한 결과가 product-list에 그대로 노출되는 문제 해결
<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->
### [🔧 WOW-77 fix:search-page와 product-list의 데이터 문제 해결](https://github.com/WoWmazon/wowmazon/commit/64619138d4c04a9a9d74c23d82d6155c256db428)
- 검색 페이지와 상품 페이지에서 useInfiniteScrollProductList()로 데이터를 가져오고 있습니다. 검색 페이지에서 검색을 한 후 상품 페이지로 넘어가면 queryKey가 같기 때문에 상품 페이지에서 검색한 결과가 남아있어 상품 페이지에 그대로 노출됩니다.
- 해당 화면

https://github.com/user-attachments/assets/a098f0de-8e9a-4426-a3d4-211bb86e6ef9

- 해당 문제를 해결하기 위해 product-list-category-filter.tsx 에서 product list를 불러올 때 search: undefined를 설정하여 검색 페이지의 queryKey와 차이를 주었습니다.

<img width="409" alt="image" src="https://github.com/user-attachments/assets/7e3b4c4c-60b6-408b-a071-f24194c8f0b5">

- 그리고 searchParams의 기본값에 search가 있을 필요가 없을 것 같아서 제거했습니다.
<img width="594" alt="image" src="https://github.com/user-attachments/assets/beadb972-b05f-4a31-9ded-f759d870a51e">

- search-container.tsx 에서 searchParams.search === "" 조건을 수정했습니다. (search의 default가 undefined이기 때문)
<img width="594" alt="image" src="https://github.com/user-attachments/assets/1fc507e4-2e97-49bf-89f4-6a844db491e1">


<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```